### PR TITLE
bug fix: if there is only one monitor available, do not try to open the game on the second monitor

### DIFF
--- a/figImpl/ColonyWindow.cpp
+++ b/figImpl/ColonyWindow.cpp
@@ -32,7 +32,8 @@ ColonyWindow::ColonyWindow(
 
   int count;
   GLFWmonitor** monitors = glfwGetMonitors(&count);
-  const GLFWvidmode* mode = glfwGetVideoMode(monitors[1]);
+  const GLFWvidmode* mode =
+    (count > 1) ? glfwGetVideoMode(monitors[1]) : glfwGetVideoMode(monitors[0]);
   _screenWidth = mode->width;
   _screenHeight = mode->height - 150;
   _window =


### PR DESCRIPTION
If we have screen - that's the screen we use to show the game window, if there are more screens available, we always show on the second.