### PR TITLE
Update resource management

### DIFF
--- a/figImpl/ColonyApplication.cpp
+++ b/figImpl/ColonyApplication.cpp
@@ -7,22 +7,18 @@
 #include "figImpl/ColonyGuiLayer.h"
 #include "figImpl/events/ColonyEventFabric.h"
 
-using namespace std::placeholders;
-
 template <typename T>
 ColonyApplication<T>::ColonyApplication() {
-  _eventFabric = std::make_unique<ColonyEventFabric>();
-  auto config = CONFIG.get();
-  int screenWidth = config.window_width;
-  int screenHeight = config.window_height;
-  auto camera = std::make_unique<fig::Camera>(glm::vec3(0.0f, -45.0f, 60.0f),
-                                              glm::vec3(0.0f, 0.0f, 0.0f),
-                                              glm::vec3(0.0f, 0.0f, 1.0f));
   std::vector<std::unique_ptr<fig::Camera>> cameras;
-  cameras.push_back(std::move(camera));
+  cameras.push_back(std::make_unique<fig::Camera>(
+      glm::vec3(0.0f, -45.0f, 60.0f), glm::vec3(0.0f, 0.0f, 0.0f),
+      glm::vec3(0.0f, 0.0f, 1.0f)));
 
-  fig::Window::Param param = {screenWidth, screenHeight};
+  auto config = CONFIG.get();
+  fig::Window::Param param = {config.window_width, config.window_height};
   std::vector<glm::vec3> lightsCoords = {glm::vec3(1.2f, 0.0f, 5.0f)};
+
+  _eventFabric = std::make_unique<ColonyEventFabric>();
   this->_appEnv = std::make_unique<fig::AppEnvPrivate>(
       std::make_unique<fig::GlfwWindow>(_eventFabric.get(), param),
       std::move(cameras), lightsCoords);
@@ -31,9 +27,7 @@ ColonyApplication<T>::ColonyApplication() {
   auto gameLayer = std::make_unique<ColonyGameLayer>(env);
   this->_appEnv.get()->window->setOnEvent(gameLayer->onEvent());
   this->addLayer(std::move(gameLayer));
-
-  auto guiLayer = std::make_unique<ColonyGuiLayer>(env);
-  this->addLayer(std::move(guiLayer));
+  this->addLayer(std::make_unique<ColonyGuiLayer>(env));
 }
 
 template <typename T>

--- a/figImpl/ColonyEventManager.cpp
+++ b/figImpl/ColonyEventManager.cpp
@@ -8,7 +8,7 @@
 ColonyEventManager::ColonyEventManager(
     glm::mat4& view, glm::mat4& projection, fig::Window& window, Game& game,
     fig::Camera& camera, fig::Terrain& terrain,
-    std::shared_ptr<fig::ObstaclesSegment> mo, fig::AStar& astar)
+    std::unique_ptr<fig::ObstaclesSegment> mapObstacles, fig::AStar& astar)
     : _view(view),
       _projection(projection),
       _window(window),
@@ -16,7 +16,7 @@ ColonyEventManager::ColonyEventManager(
       _game(game),
       _terrain(terrain),
       _selection(*SHADERS_MAP[ShaderType::LINES], camera),
-      _mapObstacles(mo),
+      _mapObstacles(std::move(mapObstacles)),
       _astar(astar) {
   // TODO downcast
   _game.setControl(
@@ -36,8 +36,7 @@ void ColonyEventManager::tick() {
   _game.tick();
 }
 
-void ColonyEventManager::setStructureToBuild(
-    std::shared_ptr<GroundStructure> structure) {
+void ColonyEventManager::setStructureToBuild(GroundStructure* structure) {
   _structureToBuild = structure;
 }
 

--- a/figImpl/ColonyEventManager.h
+++ b/figImpl/ColonyEventManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "fig/Camera.h"
 #include "fig/EventManager.h"
 #include "fig/HeightsSegment.h"
@@ -16,11 +18,21 @@ class ColonyEventManager : public fig::EventManager {
   ColonyEventManager(glm::mat4& view, glm::mat4& projection,
                      fig::Window& window, Game& game, fig::Camera& camera,
                      fig::Terrain& terrain,
-                     std::shared_ptr<fig::ObstaclesSegment> mo,
+                     std::unique_ptr<fig::ObstaclesSegment> mapObstacles,
                      fig::AStar& astar);
   void tick();
-  void setStructureToBuild(std::shared_ptr<GroundStructure> structure);
+  void setStructureToBuild(GroundStructure* structure);
   void setStructureToBuildStage(BuildStage stage);
+
+  void clearHeightSegment() { _heightsSegment.reset(); }
+  void setHeightSegment(std::unique_ptr<fig::HeightsSegment> segment) {
+    _heightsSegment = std::move(segment);
+  }
+
+  void clearObstaclesSegment() { _obstaclesSegment.reset(); }
+  void setObstaclesSegment(std::unique_ptr<fig::ObstaclesSegment> segment) {
+    _obstaclesSegment = std::move(segment);
+  }
 
  private:
   glm::mat4& _view;
@@ -33,7 +45,7 @@ class ColonyEventManager : public fig::EventManager {
   AttackUnit* _tankUnderAttack{nullptr};
   Buildable* _structureSelected{nullptr};
   Buildable* _barrierSelected{nullptr};
-  std::shared_ptr<GroundStructure> _structureToBuild{nullptr};
+  GroundStructure* _structureToBuild{nullptr};
   BuildStage _structureToBuildStage;
   Buildable* _structureUnderAttack{nullptr};
 
@@ -41,9 +53,9 @@ class ColonyEventManager : public fig::EventManager {
   fig::RectangleShape _selection;
   bool _selectionActive{false};
 
-  std::shared_ptr<fig::HeightsSegment> _heightsSegment;
-  std::shared_ptr<fig::ObstaclesSegment> _obstaclesSegment;
-  std::shared_ptr<fig::ObstaclesSegment> _mapObstacles;
+  std::unique_ptr<fig::HeightsSegment> _heightsSegment;
+  std::unique_ptr<fig::ObstaclesSegment> _obstaclesSegment;
+  std::unique_ptr<fig::ObstaclesSegment> _mapObstacles;
   fig::AStar& _astar;
 
   friend class ColonyKeyPressEvent;

--- a/figImpl/ColonyGameLayer.h
+++ b/figImpl/ColonyGameLayer.h
@@ -25,7 +25,7 @@ class ColonyGameLayer : public fig::GameLayer {
   void update() override;
   void render() override;
 
-  std::function<void(std::unique_ptr<fig::Event> event)> onEvent();
+  std::function<void(std::unique_ptr<fig::Event>)> onEvent();
 
  private:
   std::unique_ptr<fig::AStar> _astar;
@@ -33,7 +33,7 @@ class ColonyGameLayer : public fig::GameLayer {
   fig::Window* _window;
   fig::Camera* _camera;
   fig::Light* _light;
-  std::shared_ptr<fig::EventManager> _eventManager;
+  std::unique_ptr<fig::EventManager> _eventManager;
   std::unique_ptr<fig::Terrain> _terrain;
   std::unique_ptr<fig::Skybox> _skybox;
   std::unique_ptr<Game> _game;
@@ -41,5 +41,5 @@ class ColonyGameLayer : public fig::GameLayer {
   glm::mat4& _view;
   glm::mat4& _projection;
 
-  std::function<void(std::unique_ptr<fig::Event> event)> _onEvent;
+  std::function<void(std::unique_ptr<fig::Event>)> _onEvent;
 };

--- a/figImpl/events/ColonyKeyReleaseEvent.cpp
+++ b/figImpl/events/ColonyKeyReleaseEvent.cpp
@@ -2,6 +2,8 @@
 
 #include <GLFW/glfw3.h>
 
+#include <memory>
+
 #include "figImpl/ColonyEventManager.h"
 #include "logic/structures/Barrier.h"
 #include "logic/structures/Hq.h"
@@ -30,11 +32,11 @@ void ColonyKeyReleaseEvent::process(fig::Camera* camera,
     std::cout << "X pressed" << std::endl;
     if (em->_structureToBuild == nullptr) {
       em->_structureToBuildStage = BuildStage::SetAngle;
-      auto tankFactory = std::make_shared<TankFactory>(
+      auto tankFactory = std::make_unique<TankFactory>(
           em->_astar, fig::EventManager::unProject(em->_window, em->_view,
                                                    em->_projection));
-      em->_game.addStructure(tankFactory);
-      em->_structureToBuild = tankFactory;
+      em->setStructureToBuild(tankFactory.get());
+      em->_game.addStructure(std::move(tankFactory));
     } else {
       em->_structureToBuild->commit();
       em->_structureToBuild = nullptr;
@@ -44,12 +46,12 @@ void ColonyKeyReleaseEvent::process(fig::Camera* camera,
     std::cout << "C pressed" << std::endl;
     if (em->_structureToBuild == nullptr) {
       em->_structureToBuildStage = BuildStage::SetAngle;
-      auto hq = std::make_shared<Hq>(
+      auto hq = std::make_unique<Hq>(
           em, em->_astar,
           fig::EventManager::unProject(em->_window, em->_view, em->_projection),
           em->_terrain);
-      em->_game.addStructure(hq);
-      em->_structureToBuild = hq;
+      em->setStructureToBuild(hq.get());
+      em->_game.addStructure(std::move(hq));
     } else {
       em->_structureToBuild->commit();
       em->_structureToBuild = nullptr;
@@ -59,12 +61,12 @@ void ColonyKeyReleaseEvent::process(fig::Camera* camera,
     std::cout << "B pressed" << std::endl;
     if (em->_structureToBuild == nullptr) {
       em->_structureToBuildStage = BuildStage::SetAngle;
-      auto b = std::make_shared<Barrier>(
+      auto barrier = std::make_unique<Barrier>(
           fig::EventManager::unProject(em->_window, em->_view, em->_projection),
           em->_terrain, em->_astar);
-      em->_game.addStructure(b);
-      em->_game.addShroud(b->shroud());
-      em->_structureToBuild = b;
+      em->_game.addShroud(barrier->shroud());
+      em->setStructureToBuild(barrier.get());
+      em->_game.addStructure(std::move(barrier));
     } else {
       em->_structureToBuild->commit();
       em->_structureToBuild = nullptr;
@@ -74,11 +76,11 @@ void ColonyKeyReleaseEvent::process(fig::Camera* camera,
     std::cout << "T pressed" << std::endl;
     if (em->_structureToBuild == nullptr) {
       em->_structureToBuildStage = BuildStage::SetAngle;
-      auto b = std::make_shared<Turbine>(
+      auto turbine = std::make_unique<Turbine>(
           em->_game, fig::EventManager::unProject(em->_window, em->_view,
                                                   em->_projection));
-      em->_game.addStructure(b);
-      em->_structureToBuild = b;
+      em->setStructureToBuild(turbine.get());
+      em->_game.addStructure(std::move(turbine));
     } else {
       em->_structureToBuild->commit();
       em->_structureToBuild = nullptr;

--- a/figImpl/events/ColonyMousePressEvent.cpp
+++ b/figImpl/events/ColonyMousePressEvent.cpp
@@ -21,24 +21,26 @@ void ColonyMousePressedEvent::process(fig::Camera* camera,
 }
 
 void ColonyMousePressedEvent::handleMousePressedLeft(
-    fig::EventManager* eventManager) {
+    fig::EventManager* manager) {
   // TODO downcast
-  auto m = dynamic_cast<ColonyEventManager*>(eventManager);
+  auto eventManager = dynamic_cast<ColonyEventManager*>(manager);
 
-  auto c = fig::EventManager::unProject(m->_window, m->_view, m->_projection);
-  m->_selectionActive = true;
+  auto c = fig::EventManager::unProject(
+      eventManager->_window, eventManager->_view, eventManager->_projection);
+  eventManager->_selectionActive = true;
   auto tmp = c;
   tmp.z += 0.3;
-  m->_heightsSegment.reset();
-  m->_obstaclesSegment.reset();
-  m->_selection.setStart(tmp);
+  eventManager->clearHeightSegment();
+  eventManager->_obstaclesSegment.reset();
+  eventManager->_selection.setStart(tmp);
 
-  m->_tankSelected = m->_game.getAttackUnit(c, true);
-  m->_structureSelected = m->_game.getStructure(c);
-  if (!m->_structureSelected) {
-    m->_structureSelected = m->_game.getStructure(c);
-    if (!m->_structureSelected && m->_game.panelIsEmpty(Panel::Type::Units)) {
-      m->_game.clearPanel(Panel::Type::Units);
+  eventManager->_tankSelected = eventManager->_game.getAttackUnit(c, true);
+  eventManager->_structureSelected = eventManager->_game.getStructure(c);
+  if (!eventManager->_structureSelected) {
+    eventManager->_structureSelected = eventManager->_game.getStructure(c);
+    if (!eventManager->_structureSelected &&
+        eventManager->_game.panelIsEmpty(Panel::Type::Units)) {
+      eventManager->_game.clearPanel(Panel::Type::Units);
     }
   }
 }

--- a/figImpl/events/ColonyMouseReleaseEvent.cpp
+++ b/figImpl/events/ColonyMouseReleaseEvent.cpp
@@ -32,14 +32,14 @@ void ColonyMouseReleaseEvent::handleMouseReleased(
   if (m->isKeyPressed(fig::KeyButton::LEFT_SHIFT)) {
     auto bl = m->_selection.bottomLeft();
     auto tr = m->_selection.topRight();
-    m->_heightsSegment = fig::makeHeightsSegment(
+    m->setHeightSegment(fig::makeHeightsSegment(
         *SHADERS_MAP[ShaderType::COLOR_NON_FLAT], m->_terrain,
         glm::vec2(std::min(bl.x, tr.x), std::min(bl.y, tr.y)),
-        glm::vec2(std::max(bl.x, tr.x), std::max(bl.y, tr.y)));
-    m->_obstaclesSegment = fig::makeObstaclesSegment(
+        glm::vec2(std::max(bl.x, tr.x), std::max(bl.y, tr.y))));
+    m->setObstaclesSegment(fig::makeObstaclesSegment(
         *SHADERS_MAP[ShaderType::COLOR_NON_FLAT], m->_terrain,
         glm::vec2(std::min(bl.x, tr.x), std::min(bl.y, tr.y)),
-        glm::vec2(std::max(bl.x, tr.x), std::max(bl.y, tr.y)));
+        glm::vec2(std::max(bl.x, tr.x), std::max(bl.y, tr.y))));
   } else {
     m->_tanksSelected = m->_game.getVehicleGroup(m->_selection.getPoints());
   }

--- a/helpers/aliases.h
+++ b/helpers/aliases.h
@@ -7,6 +7,6 @@ class AttackUnit;
 class GroundStructure;
 class AbstractPlant;
 
-using AttackUnits = std::vector<std::shared_ptr<AttackUnit>>;
-using Structures = std::vector<std::shared_ptr<GroundStructure>>;
+using AttackUnits = std::vector<std::unique_ptr<AttackUnit>>;
+using Structures = std::vector<std::unique_ptr<GroundStructure>>;
 using Plants = std::vector<std::shared_ptr<AbstractPlant>>;

--- a/logic/Control.cpp
+++ b/logic/Control.cpp
@@ -13,9 +13,8 @@ Control::Control(Game& game, ColonyEventManager* eventManager,
       _eventManager(eventManager),
       _structurePanel(window, game, Panel::Type::Structures),
       _unitPanel(window, game, Panel::Type::Units) {
-  std::unique_ptr<AbstractBuilder> hqBuilder =
-      std::make_unique<HqBuilder>(_eventManager, terrain, router);
-  auto hqPanelItem = std::make_unique<PanelItem>(std::move(hqBuilder));
+  auto hqPanelItem = std::make_unique<PanelItem>(
+      std::make_unique<HqBuilder>(_eventManager, terrain, router));
   _structurePanel.addItem(std::move(hqPanelItem));
 }
 
@@ -43,14 +42,12 @@ void Control::clearUnitPanel() { _unitPanel.clear(); }
 void Control::clearStructurePanel() { _structurePanel.clear(); }
 
 void Control::addToUnitPanel(std::unique_ptr<AbstractUnitBuilder> builder) {
-  auto panelItem = std::make_unique<PanelItem>(std::move(builder));
-  _unitPanel.addItem(std::move(panelItem));
+  _unitPanel.addItem(std::make_unique<PanelItem>(std::move(builder)));
 }
 
 void Control::addToStructurePanel(
     std::unique_ptr<AbstractStructureBuilder> builder) {
-  auto panelItem = std::make_unique<PanelItem>(std::move(builder));
-  _structurePanel.addItem(std::move(panelItem));
+  _structurePanel.addItem(std::make_unique<PanelItem>(std::move(builder)));
 }
 
 bool Control::panelIsEmpty(Panel::Type type) const {

--- a/logic/Game.h
+++ b/logic/Game.h
@@ -15,15 +15,15 @@
 class Tank;
 class AbstractStructureBuilder;
 
-using Shrouds = std::vector<std::shared_ptr<Shroud>>;
+using Shrouds = std::vector<std::unique_ptr<Shroud>>;
 
 class Game {
  public:
-  Game();
   void tick();
-  void addTank(std::shared_ptr<Tank> tank);
-  void addStructure(std::shared_ptr<GroundStructure> buildable);
-  void addShroud(std::shared_ptr<Shroud> shroud);
+  void addTank(std::unique_ptr<Tank> tank);
+  void addTankAndDestination(std::unique_ptr<Tank> tank, glm::vec3 destination);
+  void addStructure(std::unique_ptr<GroundStructure> buildable);
+  void addShroud(std::unique_ptr<Shroud> shroud);
   void addPlant(std::shared_ptr<AbstractPlant> plant);
   void addTerrain(fig::Terrain* terrain);
   void setControl(std::unique_ptr<Control> control);

--- a/logic/builders/BarrierBuilder.cpp
+++ b/logic/builders/BarrierBuilder.cpp
@@ -1,5 +1,7 @@
 #include "BarrierBuilder.h"
 
+#include <memory>
+
 #include "figImpl/ColonyEventManager.h"
 #include "logic/structures/Barrier.h"
 
@@ -10,11 +12,13 @@ BarrierBuilder::BarrierBuilder(ColonyEventManager* eventManager,
       _astar(astar) {}
 
 void BarrierBuilder::addToGame(Game& game) {
-  auto structure = std::make_shared<Barrier>(glm::vec3(), _terrain, _astar);
-  game.addStructure(structure);
-  game.addShroud(structure->shroud());
-  _eventManager->setStructureToBuild(structure);
+  auto structure = std::make_unique<Barrier>(glm::vec3(), _terrain, _astar);
+
+  _eventManager->setStructureToBuild(structure.get());
   _eventManager->setStructureToBuildStage(BuildStage::SetPosition);
+
+  game.addShroud(structure->shroud());
+  game.addStructure(std::move(structure));
 }
 
 fig::MenuTextures BarrierBuilder::getPreviewType() {

--- a/logic/builders/HqBuilder.cpp
+++ b/logic/builders/HqBuilder.cpp
@@ -1,5 +1,7 @@
 #include "HqBuilder.h"
 
+#include <memory>
+
 #include "figImpl/ColonyEventManager.h"
 #include "logic/Game.h"
 #include "logic/structures/Hq.h"
@@ -12,10 +14,12 @@ HqBuilder::HqBuilder(ColonyEventManager* eventManager, fig::Terrain& terrain,
 
 void HqBuilder::addToGame(Game& game) {
   auto structure =
-      std::make_shared<Hq>(_eventManager, _router, glm::vec3(), _terrain);
-  game.addStructure(structure);
-  _eventManager->setStructureToBuild(structure);
+      std::make_unique<Hq>(_eventManager, _router, glm::vec3(), _terrain);
+
+  _eventManager->setStructureToBuild(structure.get());
   _eventManager->setStructureToBuildStage(BuildStage::SetPosition);
+
+  game.addStructure(std::move(structure));
 }
 
 fig::MenuTextures HqBuilder::getPreviewType() { return fig::MenuTextures::Hq; }

--- a/logic/builders/TankFactoryBuilder.cpp
+++ b/logic/builders/TankFactoryBuilder.cpp
@@ -1,5 +1,7 @@
 #include "TankFactoryBuilder.h"
 
+#include <memory>
+
 #include "figImpl/ColonyEventManager.h"
 #include "logic/Game.h"
 #include "logic/structures/TankFactory.h"
@@ -9,10 +11,12 @@ TankFactoryBuilder::TankFactoryBuilder(ColonyEventManager* eventManager,
     : AbstractStructureBuilder(eventManager), _router(router) {}
 
 void TankFactoryBuilder::addToGame(Game& game) {
-  auto structure = std::make_shared<TankFactory>(_router, glm::vec3());
-  game.addStructure(structure);
-  _eventManager->setStructureToBuild(structure);
+  auto structure = std::make_unique<TankFactory>(_router, glm::vec3());
+
+  _eventManager->setStructureToBuild(structure.get());
   _eventManager->setStructureToBuildStage(BuildStage::SetPosition);
+
+  game.addStructure(std::move(structure));
 }
 
 fig::MenuTextures TankFactoryBuilder::getPreviewType() {

--- a/logic/builders/TurbineBuilder.cpp
+++ b/logic/builders/TurbineBuilder.cpp
@@ -1,5 +1,7 @@
 #include "TurbineBuilder.h"
 
+#include <memory>
+
 #include "figImpl/ColonyEventManager.h"
 #include "logic/Game.h"
 #include "logic/structures/Turbine.h"
@@ -8,10 +10,11 @@ TurbineBuilder::TurbineBuilder(ColonyEventManager* eventManager)
     : AbstractStructureBuilder(eventManager) {}
 
 void TurbineBuilder::addToGame(Game& game) {
-  auto structure = std::make_shared<Turbine>(game, glm::vec3());
-  game.addStructure(structure);
-  _eventManager->setStructureToBuild(structure);
+  auto structure = std::make_unique<Turbine>(game, glm::vec3());
+  _eventManager->setStructureToBuild(structure.get());
   _eventManager->setStructureToBuildStage(BuildStage::SetPosition);
+
+  game.addStructure(std::move(structure));
 }
 
 fig::MenuTextures TurbineBuilder::getPreviewType() {

--- a/logic/concepts/Moving.cpp
+++ b/logic/concepts/Moving.cpp
@@ -20,7 +20,7 @@ void Moving<T>::move() {
   T& wrapped = this->wrapped();
   if (destinationIsReached || wrapped.isDestroyed()) {
     _movingRoute.pop_back();
-    wrapped._path->popLine();
+    wrapped._path.value()->popLine();
     if (!_movingRoute.empty()) {
       startMoving(_movingRoute.at(_movingRoute.size() - 1));
     } else {
@@ -34,8 +34,8 @@ void Moving<T>::setRoute(glm::vec3 endPoint) {
   T& wrapped = this->wrapped();
   wrapped._path = fig::makePath(*SHADERS_MAP[ShaderType::LINES],
                                 wrapped._router, _view->position(), endPoint);
-  if (wrapped._path != nullptr) {
-    _movingRoute = wrapped._path->route();
+  if (wrapped._path.has_value()) {
+    _movingRoute = wrapped._path.value()->route();
     startMoving(_movingRoute.at(_movingRoute.size() - 1));
   } else {
     std::cout << "No path to endpoint!" << std::endl;

--- a/logic/structures/Barrier.cpp
+++ b/logic/structures/Barrier.cpp
@@ -1,5 +1,7 @@
 #include "Barrier.h"
 
+#include <memory>
+
 #include "fig/globals.h"
 #include "logic/builders/PlantBuilder.h"
 #include "logic/builders/TreeBuilder.h"
@@ -22,7 +24,7 @@ void Barrier::render() {
       if (_livingArea != nullptr) {
         if (_clock.elapsed() >= _bioUpdateTime) {
           fig::logger.log("updating area...");
-          _terrain.updateLivingArea(_livingArea);
+          _terrain.updateLivingArea(_livingArea.get());
           _clock.reload();
         }
       }
@@ -34,13 +36,8 @@ void Barrier::render() {
 
 UnitBuilders Barrier::getUnitBuilders() {
   auto builders = UnitBuilders();
-  std::unique_ptr<AbstractUnitBuilder> pb =
-      std::make_unique<PlantBuilder>(*this, _terrain);
-  builders.push_back(std::move(pb));
-
-  std::unique_ptr<AbstractUnitBuilder> tb =
-      std::make_unique<TreeBuilder>(*this, _terrain);
-  builders.push_back(std::move(tb));
+  builders.push_back(std::make_unique<PlantBuilder>(*this, _terrain));
+  builders.push_back(std::make_unique<TreeBuilder>(*this, _terrain));
 
   return builders;
 }
@@ -68,7 +65,7 @@ void Barrier::addEnergyStructure(EnergyStructure* es) {
   _energyStructures.push_back(es);
   // TODO downcast
   BarrierView* v = dynamic_cast<BarrierView*>(_view.get());
-  v->grow(_livingArea);
+  v->grow(_livingArea.get());
 }
 
 float Barrier::radius() const {
@@ -77,6 +74,6 @@ float Barrier::radius() const {
   return v->radius();
 }
 
-std::shared_ptr<Shroud> Barrier::shroud() {
-  return std::shared_ptr<Shroud>(&_shroud);
+std::unique_ptr<Shroud> Barrier::shroud() {
+  return std::unique_ptr<Shroud>(&_shroud);
 }

--- a/logic/structures/Barrier.h
+++ b/logic/structures/Barrier.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <glm/glm.hpp>
+#include <memory>
 
 #include "fig/Terrain.h"
 #include "helpers/aliases.h"
@@ -20,14 +21,14 @@ class Barrier : public EnergyStructure {
   void addEnergyStructure(EnergyStructure* es);
   void commit() override;
   float radius() const;
-  std::shared_ptr<Shroud> shroud();
+  std::unique_ptr<Shroud> shroud();
 
  private:
   Shroud _shroud;
 
   float _radius{1.0f};
   fig::Terrain& _terrain;
-  std::shared_ptr<fig::LivingArea> _livingArea{nullptr};
+  std::unique_ptr<fig::LivingArea> _livingArea{nullptr};
   EnergyStructures _energyStructures;
   Plants _plants;
   Timer _clock;

--- a/logic/structures/Hq.cpp
+++ b/logic/structures/Hq.cpp
@@ -21,17 +21,13 @@ UnitBuilders Hq::getUnitBuilders() { return UnitBuilders(); }
 
 StructureBuilders Hq::getStructureBuilders() {
   StructureBuilders builders = StructureBuilders();
-  std::unique_ptr<AbstractStructureBuilder> tfBuilder =
-      std::make_unique<TankFactoryBuilder>(_eventManager, _router);
-  builders.push_back(std::move(tfBuilder));
+  builders.push_back(
+      std::make_unique<TankFactoryBuilder>(_eventManager, _router));
 
-  std::unique_ptr<AbstractStructureBuilder> bBuilder =
-      std::make_unique<BarrierBuilder>(_eventManager, _terrain, _router);
-  builders.push_back(std::move(bBuilder));
+  builders.push_back(
+      std::make_unique<BarrierBuilder>(_eventManager, _terrain, _router));
 
-  std::unique_ptr<AbstractStructureBuilder> tBuilder =
-      std::make_unique<TurbineBuilder>(_eventManager);
-  builders.push_back(std::move(tBuilder));
+  builders.push_back(std::make_unique<TurbineBuilder>(_eventManager));
 
   return builders;
 }

--- a/logic/structures/TankFactory.cpp
+++ b/logic/structures/TankFactory.cpp
@@ -2,8 +2,6 @@
 
 #include "logic/builders/TankBuilder.h"
 
-const int TankFactory::TANK_FACTORY_HP = 200;
-
 TankFactory::TankFactory(fig::AStar& router, glm::vec3 position)
     : GroundStructure(std::make_unique<TankFactoryView>(position)),
       _router(router) {
@@ -16,13 +14,12 @@ TankFactory::TankFactory(fig::AStar& router, glm::vec3 position)
 void TankFactory::createTank(Game& game, Tank::Type tankType,
                              HealthLevel healthLevel, Shell::Size shellSize) {
   auto p = position();
-  auto tank =
-      ::createTank(game, _router, position(), tankType, healthLevel, shellSize);
   auto d = 3.0f;
   auto tankDestination =
       glm::vec3(p.x - d * ::cos(glm::radians(_view->angle())),
                 p.y - d * ::sin(glm::radians(_view->angle())), p.z);
-  tank->setRoute(tankDestination);
+  ::createTank(game, _router, position(), tankDestination, tankType,
+               healthLevel, shellSize);
 }
 
 UnitBuilders TankFactory::getUnitBuilders() {
@@ -39,9 +36,8 @@ UnitBuilders TankFactory::getUnitBuilders() {
 void TankFactory::addUnitBuilder(UnitBuilders& builders, Tank::Type type,
                                  HealthLevel healthLevel,
                                  Shell::Size shellSize) {
-  std::unique_ptr<AbstractUnitBuilder> builder =
-      std::make_unique<TankBuilder>(*this, type, healthLevel, shellSize);
-  builders.push_back(std::move(builder));
+  builders.push_back(
+      std::make_unique<TankBuilder>(*this, type, healthLevel, shellSize));
 }
 
 StructureBuilders TankFactory::getStructureBuilders() {

--- a/logic/structures/TankFactory.h
+++ b/logic/structures/TankFactory.h
@@ -21,6 +21,6 @@ class TankFactory : public GroundStructure {
   void addUnitBuilder(UnitBuilders& builders, Tank::Type type,
                       HealthLevel healthLevel, Shell::Size shellSize);
 
-  static const int TANK_FACTORY_HP;
+  static constexpr int TANK_FACTORY_HP = 200;
   fig::AStar& _router;
 };

--- a/logic/units/Tank.cpp
+++ b/logic/units/Tank.cpp
@@ -1,5 +1,8 @@
 #include "logic/units/Tank.h"
 
+#include <glm/detail/type_vec.hpp>
+#include <memory>
+
 #include "fig/globals.h"
 #include "logic/Game.h"
 
@@ -29,11 +32,16 @@ Tank::Tank(fig::AStar& router, glm::vec3 position, Type type,
   _maxHealth = _health;
 }
 
-std::shared_ptr<Tank> createTank(Game& game, fig::AStar& router,
-                                 glm::vec3 position, Tank::Type type,
-                                 HealthLevel health, Shell::Size shellSize) {
-  auto newTank =
-      std::make_shared<Tank>(router, position, type, health, shellSize);
-  game.addTank(newTank);
-  return newTank;
+void createTank(Game& game, fig::AStar& router, glm::vec3 position,
+                Tank::Type type, HealthLevel health, Shell::Size shellSize) {
+  game.addTank(
+      std::make_unique<Tank>(router, position, type, health, shellSize));
+}
+
+void createTank(Game& game, fig::AStar& router, glm::vec3 position,
+                glm::vec3 destination, Tank::Type type, HealthLevel health,
+                Shell::Size shellSize) {
+  game.addTankAndDestination(
+      std::make_unique<Tank>(router, position, type, health, shellSize),
+      destination);
 }

--- a/logic/units/Tank.h
+++ b/logic/units/Tank.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <glm/detail/type_vec.hpp>
+
 #include "fig/Timer.h"
 #include "logic/units/AttackUnit.h"
 #include "view/TankView.h"
@@ -13,6 +15,12 @@ class Tank : public AttackUnit {
   enum class Type { Light, Medium, Heavy };
 
   Tank() = delete;
+  Tank(const Tank& other) = default;
+  Tank(Tank&& other) = default;
+  Tank& operator=(const Tank&) = default;
+  Tank& operator=(Tank&&) = default;
+  ~Tank() = default;
+
   Tank(fig::AStar& router, glm::vec3 position, Type type = Type::Light,
        HealthLevel healthLevel = HealthLevel::High,
        Shell::Size shellSize = Shell::Size::Small);
@@ -21,8 +29,12 @@ class Tank : public AttackUnit {
   Type _type;
 };
 
-std::shared_ptr<Tank> createTank(Game& game, fig::AStar& router,
-                                 glm::vec3 position,
-                                 Tank::Type type = Tank::Type::Light,
-                                 HealthLevel health = HealthLevel::High,
-                                 Shell::Size shellSize = Shell::Size::Small);
+void createTank(Game& game, fig::AStar& router, glm::vec3 position,
+                Tank::Type type = Tank::Type::Light,
+                HealthLevel health = HealthLevel::High,
+                Shell::Size shellSize = Shell::Size::Small);
+
+void createTank(Game& game, fig::AStar& router, glm::vec3 position,
+                glm::vec3 destination, Tank::Type type = Tank::Type::Light,
+                HealthLevel health = HealthLevel::High,
+                Shell::Size shellSize = Shell::Size::Small);

--- a/logic/units/Unit.cpp
+++ b/logic/units/Unit.cpp
@@ -10,8 +10,8 @@ Unit<T>::Unit(fig::AStar& router, View* view) : _router(router), _view(view) {}
 template <typename T>
 void Unit<T>::render() {
   _view->draw();
-  if (_path != nullptr) {
-    _path->render();
+  if (_path) {
+    _path.value()->render();
   }
 }
 

--- a/logic/units/Unit.h
+++ b/logic/units/Unit.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <optional>
+
 #include "fig/Path.h"
 #include "helpers/crtp_helper.h"
 #include "logic/concepts/Buildable.h"
@@ -17,7 +20,7 @@ class Unit : public crtp<T, Unit> {
   void render();
 
  protected:
-  std::shared_ptr<fig::Path> _path;
+  std::optional<std::unique_ptr<fig::Path>> _path;
   fig::AStar& _router;
   View* _view;
 };

--- a/logic/units/VehicleGroup.cpp
+++ b/logic/units/VehicleGroup.cpp
@@ -3,13 +3,13 @@
 bool VehicleGroup::empty() const { return _selected.empty(); }
 
 void VehicleGroup::startShooting(Buildable* target) {
-  for (auto& vehicle : _selected) {
+  for (auto* vehicle : _selected) {
     vehicle->startShooting(target);
   }
 }
 
 void VehicleGroup::setRoute(glm::vec3 destination) {
-  for (auto& vehicle : _selected) {
+  for (auto* vehicle : _selected) {
     vehicle->setRoute(destination);
   }
 }

--- a/logic/units/VehicleGroup.h
+++ b/logic/units/VehicleGroup.h
@@ -8,11 +8,11 @@
 
 class VehicleGroup {
  public:
-  using Selected = std::vector<std::shared_ptr<AttackUnit>>;
+  using Selected = std::vector<AttackUnit*>;
 
   VehicleGroup() = default;
-  VehicleGroup(Selected c) : _selected(std::move(c)){};
-  void add(AttackUnit* unit);
+  VehicleGroup(Selected c) : _selected(c){};
+  void add(AttackUnit* unit) { _selected.push_back(unit); };
   bool empty() const;
   void startShooting(Buildable* target);
   void setRoute(glm::vec3 destination);

--- a/view/BarrierView.cpp
+++ b/view/BarrierView.cpp
@@ -1,5 +1,6 @@
 #include "view/BarrierView.h"
 
+#include "ModelLoader.h"
 #include "fig/Circle.h"
 #include "fig/globals.h"
 #include "fig/third/gui/imgui/imgui.h"
@@ -16,7 +17,7 @@ BarrierView::BarrierView(glm::vec3 p, fig::Terrain* terrain)
           {-0.3, 0, BARRIER_HEALTH_BAR_WIDTH, BARRIER_HEALTH_BAR_HEIGHT},
           fig::TexturePackType::Initial),
       _terrain(terrain) {
-  _model = fig::modelLoader->models()[fig::Models::Barrier];
+  _model = fig::modelLoader->getModel(fig::ModelType::Barrier);
   _model->setActiveTexturesPack(fig::TexturePackType::PreBuild);
   _healthBar.setOffsetZ(1.3f);
   _healthBar.setTexture(fig::assets_dir + "/red.png");
@@ -64,7 +65,7 @@ void BarrierView::draw() {
 
 float BarrierView::radius() const { return _scaleFactor; }
 
-void BarrierView::grow(std::shared_ptr<fig::LivingArea> area) {
+void BarrierView::grow(fig::LivingArea* area) {
   _growFuture = std::async(std::launch::async, [this, area]() {
     auto finalScale = _scaleFactor + BARRIER_SCALE_INCREMENT;
     while (_scaleFactor < finalScale) {

--- a/view/BarrierView.h
+++ b/view/BarrierView.h
@@ -10,7 +10,7 @@ class BarrierView : public StructureView {
   BarrierView(glm::vec3 position, fig::Terrain* terrain);
   void draw() override;
   float radius() const;
-  void grow(std::shared_ptr<fig::LivingArea> area);
+  void grow(fig::LivingArea* area);
 
  private:
   float _scaleFactor{BARRIER_INIT_SCALE};

--- a/view/HqView.cpp
+++ b/view/HqView.cpp
@@ -1,5 +1,6 @@
 #include "view/HqView.h"
 
+#include "ModelLoader.h"
 #include "fig/globals.h"
 #include "figImpl/globals.h"
 
@@ -10,7 +11,7 @@ HqView::HqView(glm::vec3 position)
     : StructureView(position, 0.75,
                     {-0.3, 0, HQ_HEALTH_BAR_WIDTH, HQ_HEALTH_BAR_HEIGHT},
                     fig::TexturePackType::PreBuild) {
-  _model = fig::modelLoader->models()[fig::Models::Hq];
+  _model = fig::modelLoader->getModel(fig::ModelType::Hq);
   _model->setActiveTexturesPack(fig::TexturePackType::PreBuild);
   _healthBar.setOffsetZ(1.3f);
   _healthBar.setTexture(fig::assets_dir + "/red.png");

--- a/view/PlantView.cpp
+++ b/view/PlantView.cpp
@@ -4,7 +4,7 @@
 #include "fig/globals.h"
 
 PlantView::PlantView(glm::vec3 position) : AbstractPlantView(position) {
-  _model = fig::modelLoader->models()[fig::Models::Plant];
+  _model = fig::modelLoader->getModel(fig::ModelType::Plant);
   _objScale = 0.01;
 }
 

--- a/view/ShellView.cpp
+++ b/view/ShellView.cpp
@@ -3,7 +3,7 @@
 #include "fig/globals.h"
 
 ShellView::ShellView(glm::vec3 position) : View(position) {
-  _model = fig::modelLoader->models()[fig::Models::Shell];
+  _model = fig::modelLoader->getModel(fig::ModelType::Shell);
 }
 
 void ShellView::draw() {

--- a/view/ShroudView.cpp
+++ b/view/ShroudView.cpp
@@ -22,7 +22,7 @@ ShroudView::ShroudView(glm::vec3 p, float barrierHeight)
       _beamGlobe(*SHADERS_MAP[ShaderType::LINES], globeMapper(p + GLOBE_OFFSET),
                  globeMapper(glm::vec3(p.x, p.y, p.z + barrierHeight)), 0.05f,
                  5) {
-  _model = fig::modelLoader->models()[fig::Models::Shroud];
+  _model = fig::modelLoader->getModel(fig::ModelType::Shroud);
   _model->setActiveTexturesPack(fig::TexturePackType::Initial);
   _hasAnimation = true;
   _healthBar.setOffsetZ(p.z + 0.3);

--- a/view/ShroudView.h
+++ b/view/ShroudView.h
@@ -18,7 +18,6 @@ class ShroudView : public UnitView {
   bool onOrbit() const;
 
  private:
-  std::shared_ptr<fig::Model> _model;
   Timer _timer;
   bool _animate{false};
   bool _setUp{false};

--- a/view/TankFactoryView.cpp
+++ b/view/TankFactoryView.cpp
@@ -11,7 +11,7 @@ TankFactoryView::TankFactoryView(glm::vec3 position)
                     {-0.3, 0, TANK_FACTORY_HEALTH_BAR_WIDTH,
                      TANK_FACTORY_HEALTH_BAR_HEIGHT},
                     fig::TexturePackType::PreBuild) {
-  _model = fig::modelLoader->models()[fig::Models::TankFactory];
+  _model = fig::modelLoader->getModel(fig::ModelType::TankFactory);
   _model->setActiveTexturesPack(fig::TexturePackType::PreBuild);
   _healthBar.setOffsetZ(1.3f);
   _healthBar.setTexture(fig::assets_dir + "/red.png");

--- a/view/TankView.cpp
+++ b/view/TankView.cpp
@@ -1,5 +1,6 @@
 #include "view/TankView.h"
 
+#include "ModelLoader.h"
 #include "fig/globals.h"
 #include "logic/concepts/Buildable.h"
 
@@ -11,7 +12,7 @@ TankView::TankView(glm::vec3 position, float tankTypeScaling)
                      fig::TexturePackType::Initial),
       _tankTypeScaleFactor(tankTypeScaling) {
   _objScale = tankTypeScaling;
-  _model = fig::modelLoader->models()[fig::Models::Tank];
+  _model = fig::modelLoader->getModel(fig::ModelType::Tank);
   _hasAnimation = true;
   _healthBar.setOffsetZ(position.z + 0.3);
   _healthBar.setTexture(fig::assets_dir + "/red.png");

--- a/view/TreeView.cpp
+++ b/view/TreeView.cpp
@@ -3,7 +3,7 @@
 #include "fig/globals.h"
 
 TreeView::TreeView(glm::vec3 position) : AbstractPlantView(position) {
-  _model = fig::modelLoader->models()[fig::Models::Tree];
+  _model = fig::modelLoader->getModel(fig::ModelType::Tree);
   _objScale = 0.03;
 }
 

--- a/view/TurbineView.cpp
+++ b/view/TurbineView.cpp
@@ -11,7 +11,7 @@ TurbineView::TurbineView(glm::vec3 p, glm::vec3 spFlat, glm::vec3 spGlobe)
       _shroudPosFlat(spFlat),
       _shroudPosGlobe(spGlobe) {
   _objScale = TURBINE_SCALE_FACTOR;
-  _model = fig::modelLoader->models()[fig::Models::Turbine];
+  _model = fig::modelLoader->getModel(fig::ModelType::Turbine);
   _model->setActiveTexturesPack(fig::TexturePackType::PreBuild);
   _healthBar.setOffsetZ(1.3f);
   _healthBar.setTexture(fig::assets_dir + "/red.png");

--- a/view/View.h
+++ b/view/View.h
@@ -27,7 +27,7 @@ class View {
  protected:
   glm::vec3 globeMapper(glm::vec3 p) const;
   bool _hasAnimation{false};
-  std::shared_ptr<fig::Model> _model;
+  fig::Model* _model;
   fig::Shader& _shader;
   glm::vec3 _position;
   float _angle{0.0f};


### PR DESCRIPTION
Major changes:
* Let ModelLoader own the models
* Let Game own its structures
* Let Game own its attack units
* Let Barrier own its living area
* Let Game own its shrouds
* Let Unit own its path

Bugfix:
* Fix bug of shroud: shroud shadowed the _model field => not rendered
properly

Minor changes:
* Update fig submodule